### PR TITLE
fix: ranges were not calculating end of range correctly

### DIFF
--- a/src/grammar/dice.yacc
+++ b/src/grammar/dice.yacc
@@ -1012,8 +1012,11 @@ custom_symbol_dice:
             initialize_vector(&dice_sides, NUMERIC, 1);
             initialize_vector(&num_dice, NUMERIC, 1);
             initialize_vector(&result_vec, NUMERIC, 1);
-            dice_sides.content[0] = csd.content[0] + csd.length;
             num_dice.content[0] = 1;
+
+            int start_value = csd.content[0];
+            int end_value = csd.content[csd.length-1];
+            dice_sides.content[0] = end_value - start_value + 1;
 
             // Range
             err = roll_plain_sided_dice(
@@ -1021,7 +1024,7 @@ custom_symbol_dice:
                 &dice_sides,
                 &result_vec,
                 NO_EXPLOSION,
-                csd.content[0]
+                start_value
             );
 
         }else{
@@ -1079,6 +1082,7 @@ csd:
 
         int s = start.content[0];
         int e = end.content[0];
+
 
         if (s > e){
             printf("Range: %i -> %i\n", s, e);

--- a/src/grammar/dice_logic.c
+++ b/src/grammar/dice_logic.c
@@ -52,6 +52,7 @@ void mocking_tick(){
 
 
 int random_fn(int small, int big){
+    // printf("Between %i and %i\n", small, big);
     random_fn_run_count++;
 
     if(small == big){


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Existing range tests were unstable and sporadically failed. The reason? Because rolls of 10-40 were evaluated as 10-(40+10).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes. They do not dramatically decrease the test coverage metric
- [x] All new and existing tests passed.
- [x] I give my permission for my code to be used in this project under this license and any future license terms
