### PR TITLE
Fixing python parser bug, minor update to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ roll("1d20")
 #### Basic Requirements
 ```bash
 sudo apt-get install bison flex make python3-pip -y
+pip install -r reqs/requirements.txt
 make all
 ```
 

--- a/src/python/code/gnoll/parser.py
+++ b/src/python/code/gnoll/parser.py
@@ -56,7 +56,7 @@ def roll(s, verbose=False, mock=None, quiet=True, mock_const=3):
         out = out[0]
 
     if isinstance(out, list):
-        if out[0].lstrip("-").isdigit():
+        if all([x.lstrip("-").isdigit() for x in out]):
             out = [int(o) for o in out]
     elif out.lstrip("-").isdigit():
         out = int(out)


### PR DESCRIPTION
## Description

(I slightly modified the README.md to include a pip install requirements section as well as the below details.)

Python Parser Bug
While testing this, I noticed that I was getting an error when rolling Fate dice to test, but not consistently. Here's some sample output.

```python
In [25]: roll('10dF')
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In [25], line 1
----> 1 roll('10dF')

File ~/.local/lib/python3.8/site-packages/gnoll/parser.py:60, in roll(s, verbose, mock, quiet, mock_const)
     58 if isinstance(out, list):
     59     if out[0].lstrip("-").isdigit():
---> 60         out = [int(o) for o in out]
     61 elif out.lstrip("-").isdigit():
     62     out = int(out)

File ~/.local/lib/python3.8/site-packages/gnoll/parser.py:60, in <listcomp>(.0)
     58 if isinstance(out, list):
     59     if out[0].lstrip("-").isdigit():
---> 60         out = [int(o) for o in out]
     61 elif out.lstrip("-").isdigit():
     62     out = int(out)

ValueError: invalid literal for int() with base 10: '-'
> /home/f2k1/.local/lib/python3.8/site-packages/gnoll/parser.py(60)<listcomp>()
     58     if isinstance(out, list):
     59         if out[0].lstrip("-").isdigit():
---> 60             out = [int(o) for o in out]
     61     elif out.lstrip("-").isdigit():
     62         out = int(out)
Digging in with the debugger, it looks like this is due to this line in your python code:

     58     if isinstance(out, list):
     59         if out[0].lstrip("-").isdigit():
---> 60             out = [int(o) for o in out]
     61     elif out.lstrip("-").isdigit():
     62         out = int(out)
```

You're checking if the first instance is a digit, and then proceed to cast the list to integers. However, here's two example roll outputs:
```
['0', '-', '0', '+', '0', '-', '-', '+', '0', '+']
['+', '-', '-', '+', '0', '0', '+', '-', '-', '-']
```
The first one will fail because you check the 0th index and then attempt to cast '-' and '+' to integers, which fails. The second one will succeed because you just pass the whole list back as strings, which is probably fine for this.

## What was the fix?
Modifying one list of your parser:

```python
    if isinstance(out, list):
        # if out[0].lstrip("-").isdigit(): <-- Previous Code
        if all([x.lstrip("-").isdigit() for x in out]):
            out = [int(o) for o in out]
    elif out.lstrip("-").isdigit():
        out = int(out)
```
Previously you checked for the first entry, but if it was a 0 on the Fate die, it would assume all others were numerical as well. I simply changed it to validate every die result first. `All()` will introduce some slight delays in timing since you're testing every result, but it's a very simple check and should not provide any significant delay over the other work being performed already.

## How Has This Been Tested?
Using a debugger, I ran roll('10dF') a number of times and confirmed that leading 0s no longer lead to parsing issues.
I also went ahead and re-ran `make test`, which has identical output from before (there are a few failures, but nothing new since generation.)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)

I give my permission for my code to be used in this project under this license and any future license terms

## Minor note
This is my first actual OSS PR I think! So hopefully it's helpful. :)

