### PR TITLE
Test and slightly extend the Python command-line interface

### DIFF
--- a/src/python/code/gnoll/__main__.py
+++ b/src/python/code/gnoll/__main__.py
@@ -35,6 +35,14 @@ def parse_cmdline_args(args):
         help='show a breakdown into individual dice'
     )
     g.add_argument(
+        '-n',
+        '--times',
+        metavar='N',
+        type=int,
+        default=1,
+        help='execute the entire expression N times'
+    )
+    g.add_argument(
         '--no-builtins',
         action='store_true',
         help='disable built-in macros'
@@ -71,21 +79,23 @@ def parse_cmdline_args(args):
     return a
 
 
-def main(EXPR, no_builtins, **kwargs):
+def main(EXPR, times, no_builtins, **kwargs):
     """
     The entry point for gnoll when called via `python -m gnoll`
     @param EXPR - the expression
+    @param times - number of times to execute
     @param no_builtins - a flag to disable builtins
     @param **kwargs - other key word arguments to be passed to gnoll.roll
     """
-    _, [[result]], breakdown = gnoll.roll(
-        EXPR,
-        builtins=not no_builtins,
-        **kwargs)
-    if breakdown:
-        print(breakdown[0], '-->', result)
-    else:
-        print(result)
+    for _ in range(times):
+        _, [[result]], breakdown = gnoll.roll(
+            EXPR,
+            builtins=not no_builtins,
+            **kwargs)
+        if breakdown:
+            print(breakdown[0], '-->', result)
+        else:
+            print(result)
 
 
 if __name__ == '__main__':

--- a/src/python/code/gnoll/__main__.py
+++ b/src/python/code/gnoll/__main__.py
@@ -92,11 +92,16 @@ def main(EXPR, times, no_builtins, **kwargs):
             EXPR,
             builtins=not no_builtins,
             **kwargs)
-        if breakdown:
-            print(breakdown[0], '-->', result)
-        else:
-            print(result)
+        yield (breakdown[0], '-->', result) if breakdown else (result,)
+
+
+def main_with_args(args):
+    """Parse the commandline args and then run `main`
+    @param args - the arguments from the commandline (excluding the python3 call)
+    """
+    yield from main(**vars(parse_cmdline_args(args)))
 
 
 if __name__ == '__main__':
-    main(**vars(parse_cmdline_args(sys.argv[1:])))
+    for line in main_with_args(sys.argv[1:]):
+        print(*line)

--- a/tests/python/test_cli.py
+++ b/tests/python/test_cli.py
@@ -1,0 +1,20 @@
+import gnoll.__main__
+
+
+m = lambda *x: list(gnoll.__main__.main_with_args(x))
+
+
+def test_cli():
+
+    [[r]] = m('1d4')
+    assert isinstance(r, int)
+
+    [[(die1, die2), a, r]] = m('2d4', '--breakdown')
+    assert all((isinstance(x, int) for x in [die1, die2, r]))
+    assert a == '-->'
+
+    executions = m('4d6kh3', '+', '1', '--breakdown', '--times', '6', '--no-builtins')
+    assert len(executions) == 6
+    for (die1, die2, die3, die4), a, r in executions:
+        assert all((isinstance(x, int) for x in [die1, die2, die3, die4, r]))
+        assert a == '-->'


### PR DESCRIPTION
## Description
This adds tests for #441 and adds another option.

## How Has This Been Tested
I find that my new test passes when run with `pytest tests/python/test_cli.py`, but fails when run as part of `pytest tests/python`. I think that the breakdown flag is set somewhere in another test and then not cleared properly.

## Change Type 
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to change)
  - [x] Test Coverage (Additional test(s) without any extra code)
  - [ ] Documentation Improvements 
  - [ ] Code Quality / Maintenance 

## Checklist
  - [x] My code follows the code style of this project.
  - [ ] My change requires a change to the documentation & I have updated the documentation accordingly.
  - [x] I have read the **CONTRIBUTING** document.
  - [x] I have added tests to cover my changes.
  - [ ] All new and existing tests passed.
  - [x] I give my permission for my code to be used in this project under this license and any future license terms
